### PR TITLE
Refactor response parsing and transaction status detection; add unit tests

### DIFF
--- a/src/Services/Parsers/ResponseParser.php
+++ b/src/Services/Parsers/ResponseParser.php
@@ -4,29 +4,60 @@ namespace Reactmore\QiosPay\Services\Parsers;
 
 class ResponseParser
 {
+    private const STATUS_FAILED = 'GAGAL';
+    private const STATUS_SUCCESS = 'SUKSES';
+    private const STATUS_PROCESS = 'PROCESS';
+    private const STATUS_UNKNOWN = 'UNKNOWN';
+
     /**
      * Regex map dengan handler masing-masing.
+     *
+     * @var array<string, callable>
      */
     private array $patterns = [];
+
+    /**
+     * @var list<string>
+     */
+    private array $failKeywords = [
+        'gagal',
+        'transaksi sebelumnya ke id pelanggan',
+        'saldo tidak mencukupi',
+        'tidak benar',
+        'invalid',
+        'reject',
+        'tidak tersedia',
+        'error',
+        'lebih besar dari harga max',
+    ];
+
+    /**
+     * @var list<string>
+     */
+    private array $successKeywords = [
+        'alhamdulilah',
+        'sukses',
+        'berhasil',
+    ];
+
+    /**
+     * @var list<string>
+     */
+    private array $pendingKeywords = [
+        'mohon tunggu transaksi sedang diproses',
+        'sedang diproses',
+        'masih dalam proses',
+    ];
 
     public function __construct()
     {
         $this->patterns = [
-            // Harga Max Rejected
             '/^R#(\S+)\s+Saldo\s+(\w+)\s+([\d\.]+)\s+([A-Z]+\d+)\.(\d+),\s+(.*?)\s+Saldo\s+([\d\.,]+)\s*@\s*(.+)$/u' => [$this, 'parseRejectedHargaMax'],
-
-            // Voucher tidak tersedia
             '/^R#(\S+)\s+(\S+)\s+(\S+)\s+(Gagal, Voucher tidak tersedia,.*?)\s+Saldo\s([\d\.,]+)\s*@\s*(.+)$/u' => [$this, 'parseNormalSixGroups'],
-
-            // Nomor HP tidak benar
             '/^R#(\S+)\s+(\S+)\s+(\S+)\s+(Nomor HP tidak benar\..*?)\s+Saldo\s([\d\.,]+)\s*@\s*(.+)$/u' => [$this, 'parseNormalSixGroups'],
-
-            // Normal (variasi)
             '/^R#(\S+)\s+(\S+)\s+(\S+),\s+(.*?)\s+Saldo\s([\d\.,]+)\s*@\s*(.+)$/u' => [$this, 'parseNormalSixGroups'],
             '/^R#(\S+)\s+(\S+)\s+(\S+)\s+(.*?)\s+Saldo\s([\d\.,]+)\s*@\s*(.+)$/u' => [$this, 'parseNormalSixGroups'],
             '/^R#(\S+)\s+(\S+)\s+(\S+)(?:,)?\s+(.*?)\s+Saldo\s([\d\.,]+)\s*@\s*(.+)$/u' => [$this, 'parseNormalSixGroups'],
-
-            // Fallback
             '/^R#(\S+)\s+(.*?),\s+(.*?)\s+Saldo\s([\d\.,]+)\s*@\s*(.+)$/u' => [$this, 'parseNormalFiveGroups'],
         ];
     }
@@ -41,10 +72,8 @@ class ResponseParser
             }
         }
 
-        // fallback kalau nggak match apapun
         return $this->defaultParsed($body);
     }
-
 
     private function parseRejectedHargaMax(array $m, string $raw): array
     {
@@ -77,9 +106,10 @@ class ResponseParser
         $dest     = null;
 
         if ($leftPart !== '') {
-            $tokens    = preg_split('/\s+/', $leftPart);
-            $lastToken = end($tokens);
-            if (preg_match('/\d/', $lastToken)) {
+            $tokens = preg_split('/\s+/', $leftPart) ?: [];
+            $lastToken = $tokens === [] ? null : end($tokens);
+
+            if (is_string($lastToken) && preg_match('/\d/', $lastToken)) {
                 array_pop($tokens);
                 $product = implode(' ', $tokens);
                 $dest    = $lastToken;
@@ -113,7 +143,6 @@ class ResponseParser
             'raw'          => trim($raw),
         ], $data);
 
-        // Tambahkan status transaksi
         $parsed['transaction_status'] = $this->detectStatus($parsed['status_msg']);
 
         return $parsed;
@@ -122,50 +151,37 @@ class ResponseParser
     private function detectStatus(?string $statusMsg): string
     {
         if (empty($statusMsg)) {
-            return 'UNKNOWN';
+            return self::STATUS_UNKNOWN;
         }
 
-        // daftar kata kunci gagal
-        $failKeywords = [
-            'GAGAL',
-            'Gagal',
-            'Transaksi sebelumnya ke ID Pelanggan',
-            'Saldo tidak mencukupi',
-            'tidak benar',
-            'invalid',
-            'reject',
-            'tidak tersedia',
-            'error',
-            'lebih besar dari Harga Max'
-        ];
+        $normalizedStatus = mb_strtolower($statusMsg);
 
-        foreach ($failKeywords as $kw) {
-            if (stripos($statusMsg, $kw) !== false) {
-                return 'GAGAL';
+        if ($this->containsAnyKeyword($normalizedStatus, $this->failKeywords)) {
+            return self::STATUS_FAILED;
+        }
+
+        if ($this->containsAnyKeyword($normalizedStatus, $this->pendingKeywords)) {
+            return self::STATUS_PROCESS;
+        }
+
+        if ($this->containsAnyKeyword($normalizedStatus, $this->successKeywords)) {
+            return self::STATUS_SUCCESS;
+        }
+
+        return self::STATUS_UNKNOWN;
+    }
+
+    /**
+     * @param list<string> $keywords
+     */
+    private function containsAnyKeyword(string $text, array $keywords): bool
+    {
+        foreach ($keywords as $keyword) {
+            if (str_contains($text, $keyword)) {
+                return true;
             }
         }
 
-        $successKeywords = [
-            'Alhamdulilah',
-        ];
-
-        foreach ($successKeywords as $sw) {
-            if (stripos($statusMsg, $sw) !== false) {
-                return 'SUKSES';
-            }
-        }
-
-        $pendingKeywords = [
-            'Mohon tunggu transaksi sedang diproses',
-        ];
-
-        foreach ($pendingKeywords as $sw) {
-            if (stripos($statusMsg, $sw) !== false) {
-                return 'PROCESS';
-            }
-        }
-
-        // fallback 
-        return 'UNKNOWN'; // default kalau ambiguous
+        return false;
     }
 }

--- a/src/Services/Transactions.php
+++ b/src/Services/Transactions.php
@@ -28,15 +28,15 @@ class Transactions implements ServiceInterface
      *
      * @var AdapterInterface
      */
-    private $adapter;
+    private AdapterInterface $adapter;
 
     /**
      * QiosPay configuration instance.
      *
      * @var Qiospay
      */
-    private $config;
-    
+    private Qiospay $config;
+
     private ResponseParser $parser;
 
     /**
@@ -56,7 +56,7 @@ class Transactions implements ServiceInterface
         $this->adapter = $adapter;
         $this->parser  = new ResponseParser();
 
-        $this->validateConfig($config);
+        $this->validateConfig($this->config);
     }
 
     /**
@@ -140,98 +140,6 @@ class Transactions implements ServiceInterface
         } catch (RequestException $e) {
             return $this->handleException($e);
         }
-    }
-
-    /**
-     * Regex pattern untuk kasus Harga Max Rejected (semua provider)
-     */
-    private function getRejectedHargaMaxPattern(): string
-    {
-        return '/^R#(\S+)\s+Saldo\s+(\w+)\s+([\d\.]+)\s+([A-Z]+\d+)\.(\d+),\s+(.*?)\s+Saldo\s+([\d\.,]+)\s*@\s*(.+)$/u';
-    }
-
-    /**
-     * Parse response Harga Max Rejected
-     */
-    private function parseRejectedHargaMax(array $matches, string $raw): array
-    {
-        return [
-            'trx_id'       => $matches[1] ?? null,
-            'product_code' => $matches[4] ?? null,
-            'dest'         => $matches[5] ?? null,
-            'status_msg'   => trim($matches[6] ?? ''),
-            'saldo'        => $matches[7] ?? null,
-            'datetime'     => $matches[8] ?? null,
-            'raw'          => trim($raw),
-        ];
-    }
-
-    /**
-     * Parse response normal (gunakan patterns lama kamu)
-     */
-    private function parseNormalResponse(string $body): array
-    {
-        $parsed = [
-            'trx_id'       => null,
-            'product_code' => null,
-            'dest'         => null,
-            'status_msg'   => null,
-            'saldo'        => null,
-            'datetime'     => null,
-            'raw'          => trim($body),
-        ];
-
-        $patterns = [
-            // 0) Kasus khusus voucher tidak tersedia
-            '/^R#(\S+)\s+(\S+)\s+(\S+)\s+(Gagal, Voucher tidak tersedia,.*?)\s+Saldo\s([\d\.,]+)\s*@\s*(.+)$/u',
-            // 0b) Kasus khusus nomor HP tidak benar
-            '/^R#(\S+)\s+(\S+)\s+(\S+)\s+(Nomor HP tidak benar\..*?)\s+Saldo\s([\d\.,]+)\s*@\s*(.+)$/u',
-            // 1) Normal dengan koma
-            '/^R#(\S+)\s+(\S+)\s+(\S+),\s+(.*?)\s+Saldo\s([\d\.,]+)\s*@\s*(.+)$/u',
-            // 2) Normal tanpa koma
-            '/^R#(\S+)\s+(\S+)\s+(\S+)\s+(.*?)\s+Saldo\s([\d\.,]+)\s*@\s*(.+)$/u',
-            // 3) Optional comma
-            '/^R#(\S+)\s+(\S+)\s+(\S+)(?:,)?\s+(.*?)\s+Saldo\s([\d\.,]+)\s*@\s*(.+)$/u',
-            // 4) Generic fallback
-            '/^R#(\S+)\s+(.*?),\s+(.*?)\s+Saldo\s([\d\.,]+)\s*@\s*(.+)$/u',
-        ];
-
-        foreach ($patterns as $pattern) {
-            if (preg_match($pattern, $body, $matches)) {
-                $groupCount = count($matches) - 1;
-
-                if ($groupCount === 6) {
-                    $parsed['trx_id']       = $matches[1] ?? null;
-                    $parsed['product_code'] = $matches[2] ?? null;
-                    $parsed['dest']         = $matches[3] ?? null;
-                    $parsed['status_msg']   = trim($matches[4] ?? '');
-                    $parsed['saldo']        = $matches[5] ?? null;
-                    $parsed['datetime']     = $matches[6] ?? null;
-                } elseif ($groupCount === 5) {
-                    $parsed['trx_id']     = $matches[1] ?? null;
-                    $leftPart             = trim($matches[2] ?? '');
-                    $parsed['status_msg'] = trim($matches[3] ?? '');
-                    $parsed['saldo']      = $matches[4] ?? null;
-                    $parsed['datetime']   = $matches[5] ?? null;
-
-                    if ($leftPart !== '') {
-                        $tokens    = preg_split('/\s+/', $leftPart);
-                        $lastToken = end($tokens);
-                        if (preg_match('/\d/', $lastToken)) {
-                            array_pop($tokens);
-                            $parsed['product_code'] = trim(implode(' ', $tokens)) ?: $leftPart;
-                            $parsed['dest']         = $lastToken;
-                        } else {
-                            $parsed['product_code'] = $leftPart;
-                            $parsed['dest']         = null;
-                        }
-                    }
-                }
-                break;
-            }
-        }
-
-        return $parsed;
     }
 
     /**

--- a/tests/ParseTest/ParseBankTest.php
+++ b/tests/ParseTest/ParseBankTest.php
@@ -42,7 +42,11 @@ class ParseBankTest extends TestCase
         $service  = new Transactions($mockAdapter, $this->config);
         $response = $service->h2h(['product' => 'TFBCA10', 'dest' => '0953955315']);
 
-        d($response);
+        $this->assertSame('INV-1772362352', $response['trxid']);
+        $this->assertSame('PROCESS', $response['transaction_status']);
+        $this->assertSame('0953955315', $response['account']);
+        $this->assertSame('TFBCA10', $response['product']);
+        $this->assertSame('18.848', $response['saldo']);
     }
 
     public function testParseProsesTransferBCA(): void
@@ -50,8 +54,6 @@ class ParseBankTest extends TestCase
         $message = "R#INV-1772362352 TFBCA10 0953955315, Mohon tunggu transaksi sedang diproses. Saldo 18.848 @ 02\/03\/2026 01:52";
 
         $parsed = parseTransactionMessage($message);
-
-
 
         $this->assertSame('PROCESS', $parsed['status']);
     }

--- a/tests/ResponseParserTest.php
+++ b/tests/ResponseParserTest.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Tests;
+
+use Reactmore\QiosPay\Services\Parsers\ResponseParser;
+use Tests\Support\TestCase;
+
+class ResponseParserTest extends TestCase
+{
+    /**
+     * @dataProvider statusMessageProvider
+     */
+    public function testDetectTransactionStatusFromMessage(string $body, string $expectedStatus): void
+    {
+        $parser = new ResponseParser();
+        $parsed = $parser->parse($body);
+
+        $this->assertSame($expectedStatus, $parsed['transaction_status']);
+    }
+
+    public static function statusMessageProvider(): array
+    {
+        return [
+            'success keyword' => [
+                'body' => 'R#trx_01 CEK 08123, Transaksi berhasil. Saldo 10.000 @ 01/01/2026 10:00',
+                'expectedStatus' => 'SUKSES',
+            ],
+            'pending keyword' => [
+                'body' => 'R#trx_02 CEK 08123, Mohon tunggu transaksi sedang diproses. Saldo 10.000 @ 01/01/2026 10:00',
+                'expectedStatus' => 'PROCESS',
+            ],
+            'failed keyword' => [
+                'body' => 'R#trx_03 CEK 08123, Gagal karena sistem error. Saldo 10.000 @ 01/01/2026 10:00',
+                'expectedStatus' => 'GAGAL',
+            ],
+            'unknown message' => [
+                'body' => 'R#trx_04 CEK 08123, Menunggu pembaruan status. Saldo 10.000 @ 01/01/2026 10:00',
+                'expectedStatus' => 'UNKNOWN',
+            ],
+        ];
+    }
+}

--- a/tests/TransactionsServiceTest.php
+++ b/tests/TransactionsServiceTest.php
@@ -2,204 +2,142 @@
 
 namespace Tests;
 
-use Tests\Support\TestCase;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\StreamInterface;
 use Reactmore\QiosPay\Services\Transactions;
+use Reactmore\SupportAdapter\Adapter\AdapterInterface;
+use Tests\Support\TestCase;
 
 class TransactionsServiceTest extends TestCase
 {
-    public function testParseResponseHargaMaxRejected(): void
+    /**
+     * @dataProvider transactionResponseProvider
+     */
+    public function testParseTransactionResponse(string $body, array $request, array $expected): void
     {
-        $body = "R#trx_1758979420 Saldo Dana 10.000 DANA10.085155092922, diabaikan karena Harga Voucher 10.060 lebih besar dari Harga Max anda 1.000. Saldo 71.232 @27/09/2025 20:23";
-
-        $mockStream = $this->createMock(\Psr\Http\Message\StreamInterface::class);
-        $mockStream->method('__toString')->willReturn($body);
-
-        $mockResponse = $this->createMock(\Psr\Http\Message\ResponseInterface::class);
-        $mockResponse->method('getBody')->willReturn($mockStream);
-
-        $mockAdapter = $this->createMock(\Reactmore\SupportAdapter\Adapter\AdapterInterface::class);
-        $mockAdapter->expects($this->once())
-            ->method('get')
-            ->willReturn($mockResponse);
-
-        $service  = new Transactions($mockAdapter, $this->config);
-        $response = $service->h2h(['product' => 'DANA10', 'dest' => '085155092922']);
+        $service = $this->makeServiceWithResponseBody($body);
+        $response = $service->h2h($request);
 
         $this->assertTrue($response->success);
-        $this->assertSame('trx_1758979420', $response->data['trx_id']);
-        $this->assertSame('DANA10', $response->data['product_code']);
-        $this->assertSame('085155092922', $response->data['dest']);
-        $this->assertSame('GAGAL', $response->data['transaction_status']);
-        $this->assertStringContainsString('diabaikan karena Harga Voucher', $response->data['status_msg']);
-        $this->assertSame('71.232', $response->data['saldo']);
-        $this->assertSame('27/09/2025 20:23', $response->data['datetime']);
+        $this->assertSame($expected['trx_id'], $response->data['trx_id']);
+        $this->assertSame($expected['product_code'], $response->data['product_code']);
+        $this->assertSame($expected['dest'], $response->data['dest']);
+        $this->assertSame($expected['transaction_status'], $response->data['transaction_status']);
+        $this->assertStringContainsString($expected['status_msg_contains'], $response->data['status_msg']);
+        $this->assertSame($expected['saldo'], $response->data['saldo']);
+        $this->assertSame($expected['datetime'], $response->data['datetime']);
     }
 
-    public function testParseResponseProcessed(): void
+    public static function transactionResponseProvider(): array
     {
-        $body = "R#trx_1758141872 cekd 085155092922, Mohon tunggu transaksi sedang diproses. Saldo 100.543 @ 18/09/2025 10:44";
-
-        $mockStream = $this->createMock(\Psr\Http\Message\StreamInterface::class);
-        $mockStream->method('__toString')->willReturn($body);
-
-        $mockResponse = $this->createMock(\Psr\Http\Message\ResponseInterface::class);
-        $mockResponse->method('getBody')->willReturn($mockStream);
-
-        $mockAdapter = $this->createMock(\Reactmore\SupportAdapter\Adapter\AdapterInterface::class);
-        $mockAdapter->expects($this->once())
-            ->method('get')
-            ->willReturn($mockResponse);
-
-        $service  = new Transactions($mockAdapter, $this->config);
-        $response = $service->h2h(['product' => 'DANA', 'dest' => '085155092922']);
-
-        $this->assertTrue($response->success);
-        $this->assertSame('trx_1758141872', $response->data['trx_id']);
-        $this->assertSame('cekd', $response->data['product_code']);
-        $this->assertSame('085155092922', $response->data['dest']);
-        $this->assertSame('SUKSES', $response->data['transaction_status']);
-        $this->assertStringContainsString('Mohon tunggu transaksi sedang', $response->data['status_msg']);
-        $this->assertSame('100.543', $response->data['saldo']);
-        $this->assertSame('18/09/2025 10:44', $response->data['datetime']);
+        return [
+            'harga max rejected' => [
+                'body' => 'R#trx_1758979420 Saldo Dana 10.000 DANA10.085155092922, diabaikan karena Harga Voucher 10.060 lebih besar dari Harga Max anda 1.000. Saldo 71.232 @27/09/2025 20:23',
+                'request' => ['product' => 'DANA10', 'dest' => '085155092922'],
+                'expected' => [
+                    'trx_id' => 'trx_1758979420',
+                    'product_code' => 'DANA10',
+                    'dest' => '085155092922',
+                    'transaction_status' => 'GAGAL',
+                    'status_msg_contains' => 'diabaikan karena Harga Voucher',
+                    'saldo' => '71.232',
+                    'datetime' => '27/09/2025 20:23',
+                ],
+            ],
+            'processed' => [
+                'body' => 'R#trx_1758141872 cekd 085155092922, Mohon tunggu transaksi sedang diproses. Saldo 100.543 @ 18/09/2025 10:44',
+                'request' => ['product' => 'DANA', 'dest' => '085155092922'],
+                'expected' => [
+                    'trx_id' => 'trx_1758141872',
+                    'product_code' => 'cekd',
+                    'dest' => '085155092922',
+                    'transaction_status' => 'PROCESS',
+                    'status_msg_contains' => 'Mohon tunggu transaksi sedang',
+                    'saldo' => '100.543',
+                    'datetime' => '18/09/2025 10:44',
+                ],
+            ],
+            'failed' => [
+                'body' => 'R#trx_1758978632 CEKBYUQM 085155092922, GAGAL. Kode produk salah. Saldo 71.232 @ 27/09/2025 20:10',
+                'request' => ['product' => 'CEKBYUQM', 'dest' => '085155092922'],
+                'expected' => [
+                    'trx_id' => 'trx_1758978632',
+                    'product_code' => 'CEKBYUQM',
+                    'dest' => '085155092922',
+                    'transaction_status' => 'GAGAL',
+                    'status_msg_contains' => 'GAGAL.',
+                    'saldo' => '71.232',
+                    'datetime' => '27/09/2025 20:10',
+                ],
+            ],
+            'voucher not available' => [
+                'body' => 'R#trx_1759238656 DANA15 6285155092922 Gagal, Voucher tidak tersedia, silakan pilih nominal lainnya.. Saldo 88.420 @ 30/09/2025 20:24',
+                'request' => ['product' => 'DANA15', 'dest' => '6285155092922'],
+                'expected' => [
+                    'trx_id' => 'trx_1759238656',
+                    'product_code' => 'DANA15',
+                    'dest' => '6285155092922',
+                    'transaction_status' => 'GAGAL',
+                    'status_msg_contains' => 'Voucher tidak tersedia',
+                    'saldo' => '88.420',
+                    'datetime' => '30/09/2025 20:24',
+                ],
+            ],
+            'pending process from previous trx' => [
+                'body' => 'R#trx_1758143250 danabqsp 085155092922 Transaksi sebelumnya ke ID Pelanggan 085155092922 masih dalam proses.. Saldo 85.343 @ 18/09/2025 04:07',
+                'request' => ['product' => 'danabqsp', 'dest' => '085155092922'],
+                'expected' => [
+                    'trx_id' => 'trx_1758143250',
+                    'product_code' => 'danabqsp',
+                    'dest' => '085155092922',
+                    'transaction_status' => 'GAGAL',
+                    'status_msg_contains' => 'Transaksi sebelumnya',
+                    'saldo' => '85.343',
+                    'datetime' => '18/09/2025 04:07',
+                ],
+            ],
+            'phone number invalid' => [
+                'body' => 'R#trx_1759240064 DANA15 6285155092922 Nomor HP tidak benar. Saldo 88.420 @ 30/09/2025 20:47',
+                'request' => ['product' => 'DANA15', 'dest' => '6285155092922'],
+                'expected' => [
+                    'trx_id' => 'trx_1759240064',
+                    'product_code' => 'DANA15',
+                    'dest' => '6285155092922',
+                    'transaction_status' => 'GAGAL',
+                    'status_msg_contains' => 'Nomor HP tidak benar',
+                    'saldo' => '88.420',
+                    'datetime' => '30/09/2025 20:47',
+                ],
+            ],
+            'insufficient balance' => [
+                'body' => 'R#trx_1759315231 DANA15 085155092922, Saldo tidak mencukupi. Saldo 5.710 @ 01/10/2025 17:40',
+                'request' => ['product' => 'DANA15', 'dest' => '085155092922'],
+                'expected' => [
+                    'trx_id' => 'trx_1759315231',
+                    'product_code' => 'DANA15',
+                    'dest' => '085155092922',
+                    'transaction_status' => 'GAGAL',
+                    'status_msg_contains' => 'Saldo tidak mencukupi',
+                    'saldo' => '5.710',
+                    'datetime' => '01/10/2025 17:40',
+                ],
+            ],
+        ];
     }
 
-    public function testParseResponseFailed(): void
+    private function makeServiceWithResponseBody(string $body): Transactions
     {
-        $body = "R#trx_1758978632 CEKBYUQM 085155092922, GAGAL. Kode produk salah. Saldo 71.232 @ 27/09/2025 20:10";
-
-        $mockStream = $this->createMock(\Psr\Http\Message\StreamInterface::class);
+        $mockStream = $this->createMock(StreamInterface::class);
         $mockStream->method('__toString')->willReturn($body);
 
-        $mockResponse = $this->createMock(\Psr\Http\Message\ResponseInterface::class);
+        $mockResponse = $this->createMock(ResponseInterface::class);
         $mockResponse->method('getBody')->willReturn($mockStream);
 
-        $mockAdapter = $this->createMock(\Reactmore\SupportAdapter\Adapter\AdapterInterface::class);
+        $mockAdapter = $this->createMock(AdapterInterface::class);
         $mockAdapter->expects($this->once())
             ->method('get')
             ->willReturn($mockResponse);
 
-        $service  = new Transactions($mockAdapter, $this->config);
-        $response = $service->h2h(['product' => 'CEKBYUQM', 'dest' => '085155092922']);
-
-        $this->assertTrue($response->success);
-        $this->assertSame('trx_1758978632', $response->data['trx_id']);
-        $this->assertSame('CEKBYUQM', $response->data['product_code']);
-        $this->assertSame('085155092922', $response->data['dest']);
-        $this->assertSame('GAGAL', $response->data['transaction_status']);
-        $this->assertStringContainsString('GAGAL.', $response->data['status_msg']);
-        $this->assertSame('71.232', $response->data['saldo']);
-        $this->assertSame('27/09/2025 20:10', $response->data['datetime']);
-    }
-
-    public function testParseVoucherNotAvailable(): void
-    {
-        $body = "R#trx_1759238656 DANA15 6285155092922 Gagal, Voucher tidak tersedia, silakan pilih nominal lainnya.. Saldo 88.420 @ 30/09/2025 20:24";
-
-        $mockStream = $this->createMock(\Psr\Http\Message\StreamInterface::class);
-        $mockStream->method('__toString')->willReturn($body);
-
-        $mockResponse = $this->createMock(\Psr\Http\Message\ResponseInterface::class);
-        $mockResponse->method('getBody')->willReturn($mockStream);
-
-        $mockAdapter = $this->createMock(\Reactmore\SupportAdapter\Adapter\AdapterInterface::class);
-        $mockAdapter->expects($this->once())
-            ->method('get')
-            ->willReturn($mockResponse);
-
-        $service  = new Transactions($mockAdapter, $this->config);
-        $response = $service->h2h(['product' => 'DANA15', 'dest' => '6285155092922']);
-
-        $this->assertTrue($response->success);
-        $this->assertSame('trx_1759238656', $response->data['trx_id']);
-        $this->assertSame('DANA15', $response->data['product_code']);
-        $this->assertSame('6285155092922', $response->data['dest']);
-        $this->assertSame('GAGAL', $response->data['transaction_status']);
-        $this->assertStringContainsString('Gagal, Voucher tidak tersedia, silakan pilih nominal lainnya..', $response->data['status_msg']);
-        $this->assertSame('88.420', $response->data['saldo']);
-        $this->assertSame('30/09/2025 20:24', $response->data['datetime']);
-    }
-
-    public function testParseResponsePendingProcessed(): void
-    {
-        $body = "R#trx_1758143250 danabqsp 085155092922 Transaksi sebelumnya ke ID Pelanggan 085155092922 masih dalam proses.. Saldo 85.343 @ 18/09/2025 04:07";
-
-        $mockStream = $this->createMock(\Psr\Http\Message\StreamInterface::class);
-        $mockStream->method('__toString')->willReturn($body);
-
-        $mockResponse = $this->createMock(\Psr\Http\Message\ResponseInterface::class);
-        $mockResponse->method('getBody')->willReturn($mockStream);
-
-        $mockAdapter = $this->createMock(\Reactmore\SupportAdapter\Adapter\AdapterInterface::class);
-        $mockAdapter->expects($this->once())
-            ->method('get')
-            ->willReturn($mockResponse);
-
-        $service  = new Transactions($mockAdapter, $this->config);
-        $response = $service->h2h(['product' => 'danabqsp', 'dest' => '085155092922']);
-
-        $this->assertTrue($response->success);
-        $this->assertSame('trx_1758143250', $response->data['trx_id']);
-        $this->assertSame('085155092922', $response->data['dest']);
-        $this->assertSame('GAGAL', $response->data['transaction_status']);
-        $this->assertStringContainsString('danabqsp', $response->data['product_code']);
-        $this->assertStringContainsString('Transaksi sebelumnya', $response->data['status_msg']);
-        $this->assertSame('85.343', $response->data['saldo']);
-        $this->assertSame('18/09/2025 04:07', $response->data['datetime']);
-    }
-
-    public function testParsePhoneNumberInvalid(): void
-    {
-        $body = "R#trx_1759240064 DANA15 6285155092922 Nomor HP tidak benar. Saldo 88.420 @ 30/09/2025 20:47";
-
-        $mockStream = $this->createMock(\Psr\Http\Message\StreamInterface::class);
-        $mockStream->method('__toString')->willReturn($body);
-
-        $mockResponse = $this->createMock(\Psr\Http\Message\ResponseInterface::class);
-        $mockResponse->method('getBody')->willReturn($mockStream);
-
-        $mockAdapter = $this->createMock(\Reactmore\SupportAdapter\Adapter\AdapterInterface::class);
-        $mockAdapter->expects($this->once())
-            ->method('get')
-            ->willReturn($mockResponse);
-
-        $service  = new Transactions($mockAdapter, $this->config);
-        $response = $service->h2h(['product' => 'DANA15', 'dest' => '6285155092922']);
-
-        $this->assertTrue($response->success);
-        $this->assertSame('trx_1759240064', $response->data['trx_id']);
-        $this->assertSame('DANA15', $response->data['product_code']);
-        $this->assertSame('6285155092922', $response->data['dest']);
-        $this->assertSame('GAGAL', $response->data['transaction_status']);
-        $this->assertStringContainsString('Nomor HP tidak', $response->data['status_msg']);
-        $this->assertSame('88.420', $response->data['saldo']);
-        $this->assertSame('30/09/2025 20:47', $response->data['datetime']);
-    }
-
-    public function testParseInsufficientBalance(): void
-    {
-        $body = "R#trx_1759315231 DANA15 085155092922, Saldo tidak mencukupi. Saldo 5.710 @ 01/10/2025 17:40";
-
-        $mockStream = $this->createMock(\Psr\Http\Message\StreamInterface::class);
-        $mockStream->method('__toString')->willReturn($body);
-
-        $mockResponse = $this->createMock(\Psr\Http\Message\ResponseInterface::class);
-        $mockResponse->method('getBody')->willReturn($mockStream);
-
-        $mockAdapter = $this->createMock(\Reactmore\SupportAdapter\Adapter\AdapterInterface::class);
-        $mockAdapter->expects($this->once())
-            ->method('get')
-            ->willReturn($mockResponse);
-
-        $service  = new Transactions($mockAdapter, $this->config);
-        $response = $service->h2h(['product' => 'DANA15', 'dest' => '085155092922']);
-
-        $this->assertTrue($response->success);
-        $this->assertSame('trx_1759315231', $response->data['trx_id']);
-        $this->assertSame('DANA15', $response->data['product_code']);
-        $this->assertSame('085155092922', $response->data['dest']);
-        $this->assertSame('GAGAL', $response->data['transaction_status']);
-        $this->assertStringContainsString('Saldo tidak mencukupi', $response->data['status_msg']);
-        $this->assertSame('5.710', $response->data['saldo']);
-        $this->assertSame('01/10/2025 17:40', $response->data['datetime']);
+        return new Transactions($mockAdapter, $this->config);
     }
 }


### PR DESCRIPTION
### Motivation
- Improve robustness and clarity of H2H response parsing and transaction status detection by centralizing parsing logic and normalizing status matching.
- Add automated tests to ensure status classification and transaction parsing behave consistently across various message formats.

### Description
- Introduce `ResponseParser` enhancements: add status constants, keyword lists (`failKeywords`, `successKeywords`, `pendingKeywords`), normalize messages to lowercase, and implement `containsAnyKeyword` helper used by `detectStatus` to classify `transaction_status` as `GAGAL`, `SUKSES`, `PROCESS`, or `UNKNOWN`.
- Harden parsing logic in `parseNormalFiveGroups` with safer `preg_split` handling and stronger `lastToken` checks, and ensure `formatParsed` always sets `transaction_status` using `detectStatus`.
- Simplify `Transactions` service by adding proper type hints (`AdapterInterface` and `Qiospay`), calling `validateConfig($this->config)` in the constructor, and removing duplicate parsing helpers now centralized in `ResponseParser`.
- Add and refactor tests: create `tests/ResponseParserTest.php` to assert status detection and convert `tests/TransactionsServiceTest.php` to a data-driven suite with `transactionResponseProvider` and helper `makeServiceWithResponseBody`.

### Testing
- Ran unit tests `ResponseParserTest` and `TransactionsServiceTest` with `phpunit` against the modified codebase. 
- All included tests passed, confirming status detection and parsing behavior for success, pending, failed, and various response formats.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a57cb2b49c83298fdd522c4483ce95)